### PR TITLE
[docs] const vs let

### DIFF
--- a/engineering/javascript.md
+++ b/engineering/javascript.md
@@ -274,7 +274,7 @@ function foo() {
 
 ## Assignment
 
-+ Never use `var`. Prefer [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) to declare a block scope local variable; use [`const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) to declare a constant whose value can not be re-assigned in the given scope (global or local).
++ Never use `var`. Prefer [`const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) to declare a block scope local variable; use [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) to declare a variable whose value will change in the local scope.
 
 ```javascript
 // good


### PR DESCRIPTION
Never use `var`. Prefer [`const`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) to declare a block scope local variable; use [`let`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let) to declare a variable whose value will change in the local scope.