### PR TITLE
[docs] permit reassigning function arguments

### DIFF
--- a/engineering/javascript.md
+++ b/engineering/javascript.md
@@ -908,28 +908,6 @@ function foo() {
 
 + `arguments` object must not be passed or leaked anywhere. See the [reference](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#3-managing-arguments).
 
-+ Don't re-assign the arguments.
-
-```javascript
-// good
-// Use a new variable if you need to assign the value of an argument
-function fooBar(opt) {
-  let _opt = opt;
-
-  _opt = 3;
-}
-
-// bad
-function fooBar() {
-  arguments = 3;
-}
-
-// bad
-function fooBar(opt) {
-  opt = 3;
-}
-```
-
 + Use default params instead of mutating them.
 
 ```javascript


### PR DESCRIPTION
We reassign arguments all the time and it has not been an issue. The thing to be careful about is mutating objects passed-by-reference, but we often want to do exactly that.

### Proposal to remove this styleguide recommendation:

+ Don't re-assign the arguments.	

```javascript	
// good	
// Use a new variable if you need to assign the value of an argument	
function fooBar(opt) {	
  let _opt = opt;	
  _opt = 3;	
}	
// bad	
function fooBar() {	
  arguments = 3;	
}	
// bad	
function fooBar(opt) {	
  opt = 3;	
}	
```