### PR TITLE
[docs] Ember.set recommendations

### DIFF
--- a/engineering/ember.md
+++ b/engineering/ember.md
@@ -77,28 +77,26 @@ module.exports = function(environment) {
       }
     }
 ```
+### Use `set`
 
-### Use `this.get` and `this.set`
+Calling `someObj.set('prop', value)` couples your code to the fact that
+`someObj` is an Ember Object. It prevents you from passing in a
+POJO, which is sometimes preferable in testing. It also yields a more
+informative error when called with `null` or `undefined`.
 
-Calling `someObj.get('prop')` couples your code to the fact that
-`someObj` is an Ember Object. This is informative for developers. 
-It prevents you from passing in a POJO, which is sometimes preferable in testing, but then we are ensure whether we're dealing with a POJO or Ember Object.
-
-When defining a method in a controller, component, etc. you
+Although when defining a method in a controller, component, etc. you
 can be fairly sure `this` is an Ember Object, for consistency with the
-above, we still use `get`/`set`.
+above, we still use `set`.
 
 ```js
 // Good
-
-this.set('isSelected', true);
-this.get('isSelected');
-
-// Bad
-import { get, set } from '@ember/object';
+import { set } from '@ember/object';
 
 set(this, 'isSelected', true);
-get(this, 'isSelected');
+
+// Bad
+
+this.set('isSelected', true);
 ```
 
 ### Use brace expansion


### PR DESCRIPTION
In addition to this rule change recommendation, I would like to start adopting the following rules: 

+ no-get
+ use-ember-get-and-set

## 🧰 Configurations

|    | Name | Description |
|:---|:-----|:------------|
| :car: | [octane](https://github.com/ember-cli/eslint-plugin-ember/blob/master/lib/config/octane.js) | extends the `recommended` configuration by enabling octane rules. This ruleset is currently considered **unstable and experimental** :warning: as rules may be added and removed until the final ruleset is settled upon. |

## 🍟 Rules

Rules are grouped by category to help you understand their purpose.

Each rule has emojis denoting what configuration it belongs to and/or a :wrench: if the rule is fixable via the `--fix` command line option.


### Best Practices



|    | Rule ID | Description |
|:---|:--------|:------------|
| :car::wrench: | [no-get](./docs/rules/no-get.md) | require using ES5 getters instead of Ember's `get` / `getProperties` functions |
| :wrench: | [use-ember-get-and-set](./docs/rules/use-ember-get-and-set.md) | enforce usage of `Ember.get` and `Ember.set` |